### PR TITLE
Empty src attribute on Firefox 41.0.1 (Mac) prevents holder working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.DS_Store
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/lib/holder_rails/helpers.rb
+++ b/lib/holder_rails/helpers.rb
@@ -3,7 +3,7 @@ module HolderRails
     def holder_tag(size, text='', theme=nil, html_options={})
       size = "#{size}x#{size}" unless size =~ /\A\d+%?x\d+\z/
       text = text.to_s.empty? ? size : text
-      options = {:src => '', :data => {:src => "holder.js/#{size}/text:#{text}/#{theme}"}}
+      options = {:data => {:src => "holder.js/#{size}/text:#{text}/#{theme}"}}
       options = options.merge(html_options)
 
       tag :img, options

--- a/test/holder_rails_test.rb
+++ b/test/holder_rails_test.rb
@@ -5,21 +5,21 @@ class HolderRailsTest < ActionView::TestCase
   include HolderRails::Helpers
 
   test "size" do
-    assert_dom_equal '<img data-src="holder.js/100x100/text:100x100/" src="" />', holder_tag(100)
-    assert_dom_equal '<img data-src="holder.js/200x300/text:200x300/" src="" />', holder_tag('200x300')
-    assert_dom_equal '<img data-src="holder.js/100%x75/text:100%x75/" src="" />', holder_tag('100%x75')
+    assert_dom_equal '<img data-src="holder.js/100x100/text:100x100/" />', holder_tag(100)
+    assert_dom_equal '<img data-src="holder.js/200x300/text:200x300/" />', holder_tag('200x300')
+    assert_dom_equal '<img data-src="holder.js/100%x75/text:100%x75/" />', holder_tag('100%x75')
   end
 
   test "text" do
-    assert_dom_equal '<img data-src="holder.js/200x300/text:Lorem ipsum/" src="" />', holder_tag('200x300', 'Lorem ipsum')
+    assert_dom_equal '<img data-src="holder.js/200x300/text:Lorem ipsum/" />', holder_tag('200x300', 'Lorem ipsum')
   end
 
   test "theme" do
-    assert_dom_equal '<img data-src="holder.js/200x300/text:Lorem ipsum/social" src="" />', holder_tag('200x300', 'Lorem ipsum', 'social')
+    assert_dom_equal '<img data-src="holder.js/200x300/text:Lorem ipsum/social" />', holder_tag('200x300', 'Lorem ipsum', 'social')
   end
 
   test "html_options" do
-    assert_dom_equal '<img class="special" data-src="holder.js/500x800/text:Example text/gray" id="new" src="" />',
+    assert_dom_equal '<img class="special" data-src="holder.js/500x800/text:Example text/gray" id="new" />',
       holder_tag('500x800', 'Example text', 'gray', :id => 'new', :class => 'special')
   end
 end


### PR DESCRIPTION
Hi

The blank "src" attribute in the helper prevented the holder from showing in Firefox.

Best
Warren